### PR TITLE
use the json_data table to return location identifier and montitoring…

### DIFF
--- a/src/test/resources/testData/json_data.csv
+++ b/src/test/resources/testData/json_data.csv
@@ -1,0 +1,5 @@
+"json_data_id","start_time","response_time","response_code","url","api","script_name","script_pid","parameters","json_content","partition_number","uuid"
+1,"2020-07-31 13:53:01.42","2020-07-31 13:53:01.5",200,someUrl,API,someScriptName,2239,"{\"locationIdentifier\": \"393215104490001\"}","{\"some\": \"json\"}",7,null
+3,"2020-07-31 13:53:01.42","2020-07-31 13:53:01.5",200,someUrl,API,someScriptName,2239,"{\"locationIdentifier\": \"123456789\"}","{\"some\": \"json\"}",7,null
+4,"2020-07-31 13:53:01.42","2020-07-31 13:53:01.5",200,someUrl,API,someScriptName,2239,"{\"locationIdentifier\": \"393215104490002\"}","{\"some\": \"json\"}",7,null
+34046611,"2020-07-31 13:53:01.42","2020-07-31 13:53:01.5",200,someUrl,API,someScriptName,2239,"{\"locationIdentifier\": \"405215084335400-OH015\"}","{\"some\": \"json\"}",11,null

--- a/src/test/resources/testData/table-ordering.txt
+++ b/src/test/resources/testData/table-ordering.txt
@@ -1,3 +1,4 @@
+json_data
 field_visit_header_info
 field_visit_readings_by_loc
 datum_converted_values


### PR DESCRIPTION
… location identifier, rather than the field visit tables, which may be empty.  This allows for orphan data handling in the discrete loader.

Before making a pull request
----------------------------

- [ ] Make sure all tests run
- [ ] Update the changelog appropriately

Title
-----------
https://internal.cida.usgs.gov/jira/browse/IOW-760

Description
-----------
We now grab the location identifier and monitoring location identifier from the "parent" table in the etl, json_data.  This ensures that even we have empty data, we can still pass along these two ids to the next lambda, which can then perform delete operations for the empty dataset in the observations database.

After making a pull request
---------------------------
- [x] If appropriate, put the link to the PR in the JIRA ticket
- [x] Assign someone to review unless the change is trivial
